### PR TITLE
Removed unnecessary Context param to simplify the setButtonsMenu() API 

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -78,7 +78,7 @@ Android implementation
 
 ```java
 FabOptions fabOptions = (FabOptions) findViewById(R.id.fab_options);
-fabOptions.setButtonsMenu(this, R.menu.your_fab_buttons);
+fabOptions.setButtonsMenu(R.menu.your_fab_buttons);
 ```
        
        

--- a/faboptions/src/main/java/com/joaquimley/faboptions/FabOptions.java
+++ b/faboptions/src/main/java/com/joaquimley/faboptions/FabOptions.java
@@ -96,6 +96,14 @@ public class FabOptions extends FrameLayout implements View.OnClickListener {
         }
     }
 
+    /**
+     * Deprecated. Use {@link #setButtonsMenu(int)} instead.
+     */
+    @Deprecated
+    public void setButtonsMenu(Context context, @MenuRes int menuId) {
+        setButtonsMenu(menuId);
+    }
+
     public void setButtonsMenu(@MenuRes int menuId) {
         Context context = getContext();
         mMenu = new MenuBuilder(context);

--- a/faboptions/src/main/java/com/joaquimley/faboptions/FabOptions.java
+++ b/faboptions/src/main/java/com/joaquimley/faboptions/FabOptions.java
@@ -92,11 +92,12 @@ public class FabOptions extends FrameLayout implements View.OnClickListener {
     private void inflateButtonsFromAttrs(Context context, AttributeSet attrs) {
         TypedArray attributes = context.getTheme().obtainStyledAttributes(attrs, R.styleable.FabOptions, 0, 0);
         if (attributes.hasValue(R.styleable.FabOptions_button_menu)) {
-            setButtonsMenu(context, attributes.getResourceId(R.styleable.FabOptions_button_menu, 0));
+            setButtonsMenu(attributes.getResourceId(R.styleable.FabOptions_button_menu, 0));
         }
     }
 
-    public void setButtonsMenu(Context context, @MenuRes int menuId) {
+    public void setButtonsMenu(@MenuRes int menuId) {
+        Context context = getContext();
         mMenu = new MenuBuilder(context);
         SupportMenuInflater menuInf = new SupportMenuInflater(context);
         menuInf.inflate(menuId, mMenu);

--- a/sample/src/main/java/com/joaquimley/sample/JavaSampleActivity.java
+++ b/sample/src/main/java/com/joaquimley/sample/JavaSampleActivity.java
@@ -54,7 +54,7 @@ public class JavaSampleActivity extends AppCompatActivity implements View.OnClic
         setSupportActionBar(mToolbar);
 
         FabOptions fabOptions = (FabOptions) findViewById(R.id.fab_options);
-        fabOptions.setButtonsMenu(this, R.menu.menu_faboptions);
+        fabOptions.setButtonsMenu(R.menu.menu_faboptions);
         fabOptions.setOnClickListener(this);
     }
 


### PR DESCRIPTION
Every View on Android has access to Context through the ```getContext()``` method, so it's unnecessary to require the user to pass the Context as a parameter. We can just get the context using that method instead.

So instead of this:
```java
fabOptions.setButtonsMenu(this, R.menu.your_fab_buttons);
```

The user can now do this:
```java
fabOptions.setButtonsMenu(R.menu.your_fab_buttons);
```

**Both ways still work**, but I deprecated the old one and added a JavaDoc reference pointing to the new way. So it's 100% backwards compatible, but encourages the user to use the new simpler method.